### PR TITLE
Feat/ Disable Cookie Auhentication due to a unexpected problem;

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -7,8 +7,7 @@ class Api::V1::UsersController < ApplicationController
 
     if user.save
       token = encode_token({ user_id: user.id })
-      cookies.signed[:jwt] = { value: token, httponly: true, expires: 1.hour.from_now }
-      render json: { username: user.username, email: user.email }
+      render json: { username: user.username, email: user.email, token: token }
     else
       render json: { error: 'Invalid username or password', status: :invalid_user }
     end
@@ -20,16 +19,10 @@ class Api::V1::UsersController < ApplicationController
 
     if user&.authenticate(params[:user][:password])
       token = encode_token({ user_id: user.id })
-      cookies.signed[:jwt] = { value: token, httponly: true, expires: 1.hour.from_now }
-      render json: { username: user.username, email: user.email }
+      render json: { username: user.username, email: user.email, token: token }
     else
       render json: { error: 'Invalid username or password', status: :user_not_found }
     end
-  end
-
-  # DELETE /users/1
-  def destroy
-    cookies.delete(:jwt)
   end
 
   private

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::UsersController < ApplicationController
 
     if user.save
       token = encode_token({ user_id: user.id })
-      render json: { username: user.username, email: user.email, token: token }
+      render json: { user: { username: user.username, email: user.email }, token: "Bearer #{token}" }
     else
       render json: { error: 'Invalid username or password', status: :invalid_user }
     end
@@ -19,7 +19,7 @@ class Api::V1::UsersController < ApplicationController
 
     if user&.authenticate(params[:user][:password])
       token = encode_token({ user_id: user.id })
-      render json: { username: user.username, email: user.email, token: token }
+      render json: { user: { username: user.username, email: user.email }, token: "Bearer #{token}" }
     else
       render json: { error: 'Invalid username or password', status: :user_not_found }
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::API
   def decoded_token
     return unless auth_header
 
-    token = auth_header.split(' ')[1]
+    token = auth_header.split[1]
     # header: { 'Authorization': 'Bearer <token>' }
     begin
       JWT.decode(token, SECRET_KEY, true, algorithm: 'HS256')

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::API
-  include ::ActionController::Cookies
   before_action :authorized
   SECRET_KEY = 'HaNJLisLook1ng'.freeze
 
@@ -9,16 +8,16 @@ class ApplicationController < ActionController::API
 
   def auth_header
     # { Authorization: 'Bearer <token>' }
-    cookies.signed[:jwt]
+    request.headers['Authorization']
   end
 
   def decoded_token
     return unless auth_header
 
-    puts auth_header
+    token = auth_header.split(' ')[1]
     # header: { 'Authorization': 'Bearer <token>' }
     begin
-      JWT.decode(auth_header, SECRET_KEY, true, algorithm: 'HS256')
+      JWT.decode(token, SECRET_KEY, true, algorithm: 'HS256')
     rescue JWT::DecodeError
       nil
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,7 @@ module RentalcarsBackend
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
-    config.middleware.use ActionDispatch::Cookies
+    
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,8 +7,15 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins '*'
-
-    resource '*', headers: :any, methods: %i[get post put patch delete options head]
+    origins 'http://localhost:3000'
+    resource '*',
+          headers: :any,
+          methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+  allow do
+      origins 'https://my-app-frontend.netlify.app'
+      resource '*',
+            headers: :any,
+            methods: [:get, :post, :put, :patch, :delete, :options, :head]
   end
 end


### PR DESCRIPTION
Hi There!

In this PR I'm undoing the changes I made to use the cookie authentication system because nowadays browsers don't allow cross-domain cookies, even though rails have a gem to skip that behavior on google chrome, safari, and Mozilla needs an extra configuration that the user needs to set up to make these cross-domain cookies to be stored in the browser. 